### PR TITLE
Icesurfer-Cleaning duplicated "using"

### DIFF
--- a/icesurfer/Core.cs
+++ b/icesurfer/Core.cs
@@ -4,12 +4,9 @@ using OpenTK;
 using OpenTK.Input;
 using ClassicalSharp.Entities;
 using ClassicalSharp.Events;
-using System;
 using ClassicalSharp.Gui;
 using ClassicalSharp.Gui.Screens;
-using ClassicalSharp.Entities;
 using System.IO.Compression;
-using OpenTK;
 
     namespace IceSurferPlugin
     {


### PR DESCRIPTION
Corrected the source to prevent these errors:
warning CS0105: related to 'System' 
warning CS0105: related to 'ClassicalSharp.Entities' 
warning CS0105: related to 'OpenTK' 